### PR TITLE
increase penalties to dispersion at low skills.

### DIFF
--- a/data/json/character_modifiers.json
+++ b/data/json/character_modifiers.json
@@ -16,9 +16,9 @@
   {
     "type": "character_mod",
     "id": "aim_speed_mod",
-    "description": "Gun aim speed modifier <color_dark_gray>(Manipulation)</color>",
+    "description": "Gun aim speed modifier <color_dark_gray>(Manipulation, Grip, Lift)</color> ",
     "mod_type": "x",
-    "value": { "limb_score": "manip", "limb_type": "hand" }
+    "value": { "limb_score": [ [ "grip", 0.2 ], [ "manip", 0.2 ], [ "lift", 0.6 ] ], "limb_score_op": "+", "min": 0.1, "max": 1.0 }
   },
   {
     "type": "character_mod",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1062,7 +1062,8 @@ double Character::aim_per_move( const item &gun, double recoil,
     aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
 
     // add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10
-    double base_aim_speed_cap = 5.0 +  1.0 * get_skill_level( gun_skill ) + std::max( 10.0, 3.0 * get_skill_level( gun_skill ) );
+    double base_aim_speed_cap = 5.0 +  1.0 * get_skill_level( gun_skill ) + std::max( 10.0,
+                                3.0 * get_skill_level( gun_skill ) );
 
     // This upper limit usually only affects the first half of the aiming process
     // Pistols have a much higher aiming speed limit

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1058,6 +1058,8 @@ double Character::aim_per_move( const item &gun, double recoil,
 
     aim_speed *= get_modifier( character_modifier_aim_speed_mod );
 
+	// finally multiply everything by a harsh function that is eliminated by 7.5 gunskill
+    aim_speed /= std::max( 1.0, 2.5 - 0.2 * get_skill_level( gun_skill ) );
     // Use a milder attenuation function to replace the previous logarithmic attenuation function when recoil is closed to 0.
     aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1061,7 +1061,8 @@ double Character::aim_per_move( const item &gun, double recoil,
     // Use a milder attenuation function to replace the previous logarithmic attenuation function when recoil is closed to 0.
     aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
 
-    double base_aim_speed_cap = 20 +  1.0 * get_skill_level( gun_skill );
+    // add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10
+    double base_aim_speed_cap = 5.0 +  1.0 * get_skill_level( gun_skill ) + std::max( 10.0, 3.0 * get_skill_level( gun_skill ) );
 
     // This upper limit usually only affects the first half of the aiming process
     // Pistols have a much higher aiming speed limit

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1058,7 +1058,7 @@ double Character::aim_per_move( const item &gun, double recoil,
 
     aim_speed *= get_modifier( character_modifier_aim_speed_mod );
 
-	// finally multiply everything by a harsh function that is eliminated by 7.5 gunskill
+    // finally multiply everything by a harsh function that is eliminated by 7.5 gunskill
     aim_speed /= std::max( 1.0, 2.5 - 0.2 * get_skill_level( gun_skill ) );
     // Use a milder attenuation function to replace the previous logarithmic attenuation function when recoil is closed to 0.
     aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3155,7 +3155,10 @@ void target_ui::recalc_aim_turning_penalty()
     } else {
         // Raise it proportionally to how much
         // the player has to turn from previous aiming point
-        const double recoil_per_degree = MAX_RECOIL / 180.0;
+        // the player loses their aim more quickly if less skilled, normalizing at 5 skill.
+        /** @EFFECT_GUN increases the penalty for reorienting aim while below 5 */
+        const double skill_penalty = std::max( 0.0, 5.0 - you->get_skill_level( skill_gun ) );
+        const double recoil_per_degree = skill_penalty * MAX_RECOIL / 180.0;
         const units::angle angle_curr = coord_to_angle( src, curr_recoil_pos );
         const units::angle angle_desired = coord_to_angle( src, dst );
         const units::angle phi = normalize( angle_curr - angle_desired );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2149,7 +2149,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
         return 0.0;
     }
     double skill_shortfall = static_cast<double>( MAX_SKILL ) - skill;
-    double dispersion_penalty = 3 * skill_shortfall;
+    double dispersion_penalty = 10 * skill_shortfall;
     double skill_threshold = 5;
     if( skill >= skill_threshold ) {
         double post_threshold_skill_shortfall = static_cast<double>( MAX_SKILL ) - skill;
@@ -2160,7 +2160,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
     // Unskilled shooters suffer greater penalties, still scaling with weapon penalties.
     double pre_threshold_skill_shortfall = skill_threshold - skill;
     dispersion_penalty += weapon_dispersion *
-                          ( 1.25 + pre_threshold_skill_shortfall * 3.75 / skill_threshold );
+                          ( 1.25 + pre_threshold_skill_shortfall * 10.0 / skill_threshold );
 
     return dispersion_penalty;
 }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1592,13 +1592,13 @@ TEST_CASE( "gun_or_other_ranged_weapon_attributes", "[iteminfo][weapon][gun]" )
                "--\n"
                "<color_c_white>Base aim speed</color>: <color_c_yellow>29</color>\n"
                "<color_c_cyan>Regular</color>\n"
-               "Even chance of good hit at range: <color_c_yellow>3</color>\n"
+               "Even chance of good hit at range: <color_c_yellow>2</color>\n"
                "Time to reach aim level: <color_c_yellow>233</color> moves\n"
                "<color_c_cyan>Careful</color>\n"
-               "Even chance of good hit at range: <color_c_yellow>6</color>\n"
+               "Even chance of good hit at range: <color_c_yellow>3</color>\n"
                "Time to reach aim level: <color_c_yellow>399</color> moves\n"
                "<color_c_cyan>Precise</color>\n"
-               "Even chance of good hit at range: <color_c_yellow>8</color>\n"
+               "Even chance of good hit at range: <color_c_yellow>4</color>\n"
                "Time to reach aim level: <color_c_yellow>645</color> moves\n" );
     }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1590,16 +1590,16 @@ TEST_CASE( "gun_or_other_ranged_weapon_attributes", "[iteminfo][weapon][gun]" )
         std::vector<iteminfo_parts> aim_stats = { iteminfo_parts::GUN_AIMING_STATS };
         CHECK( item_info_str( glock, aim_stats ) ==
                "--\n"
-               "<color_c_white>Base aim speed</color>: <color_c_yellow>48</color>\n"
+               "<color_c_white>Base aim speed</color>: <color_c_yellow>29</color>\n"
                "<color_c_cyan>Regular</color>\n"
                "Even chance of good hit at range: <color_c_yellow>3</color>\n"
-               "Time to reach aim level: <color_c_yellow>99</color> moves\n"
+               "Time to reach aim level: <color_c_yellow>233</color> moves\n"
                "<color_c_cyan>Careful</color>\n"
                "Even chance of good hit at range: <color_c_yellow>6</color>\n"
-               "Time to reach aim level: <color_c_yellow>165</color> moves\n"
+               "Time to reach aim level: <color_c_yellow>399</color> moves\n"
                "<color_c_cyan>Precise</color>\n"
                "Even chance of good hit at range: <color_c_yellow>8</color>\n"
-               "Time to reach aim level: <color_c_yellow>263</color> moves\n" );
+               "Time to reach aim level: <color_c_yellow>645</color> moves\n" );
     }
 
     SECTION( "compatible magazines" ) {

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -170,7 +170,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
-        CHECK( good_stats.avg() > 0.05 );
+        CHECK( good_stats.avg() >= 0.05 );
     }
     {
         const dispersion_sources dispersion = get_dispersion( shooter, 500, max_good_range );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -162,7 +162,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
     {
         const dispersion_sources dispersion = get_dispersion( shooter, 300, min_good_range );
         firing_statistics good_stats = firing_test( dispersion, min_good_range, Threshold( accuracy_goodhit,
-                                       0.5 ) );
+                                       0.05 ) );
         INFO( dispersion );
         INFO( "Range: " << min_good_range );
         INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL ) );
@@ -190,7 +190,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
 static void test_fast_shooting( npc &shooter, const int moves, float hit_rate )
 {
     const int fast_shooting_range = 3;
-    const float hit_rate_cap = hit_rate + 0.3f;
+    const float hit_rate_cap = hit_rate + 0.5f;
     const dispersion_sources dispersion = get_dispersion( shooter, moves, fast_shooting_range );
     firing_statistics fast_stats = firing_test( dispersion, fast_shooting_range,
                                    Threshold( accuracy_standard, hit_rate ) );
@@ -249,32 +249,32 @@ TEST_CASE( "unskilled_shooter_accuracy", "[ranged] [balance] [slow]" )
     SECTION( "an unskilled shooter with a common pistol" ) {
         arm_shooter( shooter, "glock_19" );
         test_shooting_scenario( shooter, 4, 5, 17 );
-        test_fast_shooting( shooter, 60, 0.3 );
+        test_fast_shooting( shooter, 60, 0.15 );
     }
     SECTION( "an unskilled archer with a common bow" ) {
         arm_shooter( shooter, "shortbow", { "bow_sight_pin" }, "arrow_field_point_fletched" );
         test_shooting_scenario( shooter, 4, 4, 13 );
-        test_fast_shooting( shooter, 90, 0.3 );
+        test_fast_shooting( shooter, 90, 0.1 );
     }
     SECTION( "an unskilled archer with a common crossbow" ) {
         arm_shooter( shooter, "crossbow", {}, "bolt_makeshift" );
         test_shooting_scenario( shooter, 4, 5, 17 );
-        test_fast_shooting( shooter, 80, 0.3 );
+        test_fast_shooting( shooter, 80, 0.15 );
     }
     SECTION( "an unskilled shooter with a common shotgun" ) {
         arm_shooter( shooter, "remington_870" );
         test_shooting_scenario( shooter, 4, 4, 19 );
-        test_fast_shooting( shooter, 80, 0.3 );
+        test_fast_shooting( shooter, 80, 0.15 );
     }
     SECTION( "an unskilled shooter with a common smg" ) {
         arm_shooter( shooter, "mp40semi" );
         test_shooting_scenario( shooter, 4, 5, 18 );
-        test_fast_shooting( shooter, 80, 0.3 );
+        test_fast_shooting( shooter, 80, 0.15 );
     }
     SECTION( "an unskilled shooter with a common rifle" ) {
         arm_shooter( shooter, "ar15" );
         test_shooting_scenario( shooter, 5, 5, 25 );
-        test_fast_shooting( shooter, 100, 0.3 );
+        test_fast_shooting( shooter, 100, 0.15 );
     }
 }
 
@@ -290,32 +290,32 @@ TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
     SECTION( "a skilled shooter with an accurate pistol" ) {
         arm_shooter( shooter, "sw_619", { "red_dot_sight" } );
         test_shooting_scenario( shooter, 10, 12, 35 );
-        test_fast_shooting( shooter, 40, 0.4 );
+        test_fast_shooting( shooter, 40, 0.35 );
     }
     SECTION( "a skilled archer with an accurate bow" ) {
         arm_shooter( shooter, "recurbow", { "bow_sight" } );
         test_shooting_scenario( shooter, 8, 10, 35 );
-        test_fast_shooting( shooter, 70, 0.4 );
+        test_fast_shooting( shooter, 70, 0.35 );
     }
     SECTION( "a skilled archer with an accurate crossbow" ) {
         arm_shooter( shooter, "compositecrossbow", { "tele_sight" }, "bolt_steel" );
         test_shooting_scenario( shooter, 9, 10, 35 );
-        test_fast_shooting( shooter, 70, 0.4 );
+        test_fast_shooting( shooter, 70, 0.35 );
     }
     SECTION( "a skilled shooter with a nice shotgun" ) {
         arm_shooter( shooter, "mossberg_590" );
         test_shooting_scenario( shooter, 9, 12, 35 );
-        test_fast_shooting( shooter, 70, 0.4 );
+        test_fast_shooting( shooter, 70, 0.35 );
     }
     SECTION( "a skilled shooter with a nice smg" ) {
         arm_shooter( shooter, "hk_mp5", { "red_dot_sight" } );
         test_shooting_scenario( shooter, 9, 12, 35 );
-        test_fast_shooting( shooter, 80, 0.4 );
+        test_fast_shooting( shooter, 80, 0.3 );
     }
     SECTION( "a skilled shooter with a carbine" ) {
         arm_shooter( shooter, "m4_carbine", { "red_dot_sight" }, "556_m855a1" );
         test_shooting_scenario( shooter, 10, 15, 48 );
-        test_fast_shooting( shooter, 80, 0.4 );
+        test_fast_shooting( shooter, 80, 0.3 );
     }
     SECTION( "a skilled shooter with an available sniper rifle" ) {
         arm_shooter( shooter, "M24" );
@@ -518,7 +518,7 @@ TEST_CASE( "shot_features", "[gun]" "[slow]" )
 
     // BUCKSHOT
     // Unarmored target
-    shoot_monster( "shotgun_s", {}, "shot_00", 18, 86, "mon_wolf_mutant_huge" );
+    shoot_monster( "shotgun_s", {}, "shot_00", 18, 72, "mon_wolf_mutant_huge" );
     // Heavy damage at range.
     shoot_monster( "shotgun_s", {}, "shot_00", 12, 120, "mon_wolf_mutant_huge" );
     // More damage at close range.
@@ -529,14 +529,14 @@ TEST_CASE( "shot_features", "[gun]" "[slow]" )
     // Lightly armored target (armor_bullet: 5)
     // Outcomes for lightly armored enemies are very similar.
     shoot_monster( "shotgun_s", {}, "shot_00", 18, 33, "mon_zombie_brute" );
-    shoot_monster( "shotgun_s", {}, "shot_00", 12, 57, "mon_zombie_brute" );
+    shoot_monster( "shotgun_s", {}, "shot_00", 12, 40, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 5, 116, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 1, 73, "mon_zombie_brute" );
 
     // Armored target (armor_bullet: 10)
     shoot_monster( "shotgun_s", {}, "shot_00", 18, 8, "mon_smoker_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 12, 18, "mon_smoker_brute" );
-    shoot_monster( "shotgun_s", {}, "shot_00", 5, 62, "mon_smoker_brute" );
+    shoot_monster( "shotgun_s", {}, "shot_00", 5, 47, "mon_smoker_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 1, 72, "mon_smoker_brute" );
 }
 
@@ -559,24 +559,24 @@ TEST_CASE( "shot_features_with_choke", "[gun]" "[slow]" )
     shoot_monster( "shotgun_s", { "choke" }, "shot_bird", 1, 61, "mon_zombie_brute" );
 
     // Unarmored target
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 111, "mon_wolf_mutant_huge" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 95, "mon_wolf_mutant_huge" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 144, "mon_wolf_mutant_huge" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 5, 165, "mon_wolf_mutant_huge" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 1, 75, "mon_wolf_mutant_huge" );
     // Triviallly armored target (armor_bullet: 1)
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 50, "mon_zombie_tough" );
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 81, "mon_zombie_tough" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 32, "mon_zombie_tough" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 61, "mon_zombie_tough" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 5, 105, "mon_zombie_tough" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 1, 100, "mon_zombie_tough" );
     // Armored target (armor_bullet: 5)
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 46, "mon_zombie_brute" );
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 77, "mon_zombie_brute" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 25, "mon_zombie_brute" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 54, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 5, 124, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 1, 73, "mon_zombie_brute" );
     // Armored target (armor_bullet: 10)
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 11, "mon_smoker_brute" );
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 26, "mon_smoker_brute" );
-    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 5, 81, "mon_smoker_brute" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 18, 10, "mon_smoker_brute" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 12, 11, "mon_smoker_brute" );
+    shoot_monster( "shotgun_s", { "choke" }, "shot_00", 5, 62, "mon_smoker_brute" );
     shoot_monster( "shotgun_s", { "choke" }, "shot_00", 1, 71, "mon_smoker_brute" );
 }
 

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -170,7 +170,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
-        CHECK( good_stats.avg() >= 0.05 );
+        CHECK( good_stats.avg() > 0.0 );
     }
     {
         const dispersion_sources dispersion = get_dispersion( shooter, 500, max_good_range );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -162,7 +162,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
     {
         const dispersion_sources dispersion = get_dispersion( shooter, 300, min_good_range );
         firing_statistics good_stats = firing_test( dispersion, min_good_range, Threshold( accuracy_goodhit,
-                                       0.05 ) );
+                                       0.5 ) );
         INFO( dispersion );
         INFO( "Range: " << min_good_range );
         INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL ) );
@@ -170,7 +170,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
-        CHECK( good_stats.avg() > 0.5 );
+        CHECK( good_stats.avg() > 0.05 );
     }
     {
         const dispersion_sources dispersion = get_dispersion( shooter, 500, max_good_range );
@@ -210,7 +210,7 @@ static void test_fast_shooting( npc &shooter, const int moves, float hit_rate )
     CHECK( fast_stats.avg() > hit_rate );
     CAPTURE( fast_stats_upper.n() );
     CAPTURE( fast_stats_upper.margin_of_error() );
-    CHECK( fast_stats_upper.avg() < hit_rate_cap );
+    CHECK( fast_stats_upper.avg() <= hit_rate_cap );
 }
 
 static void assert_encumbrance( npc &shooter, int encumbrance )
@@ -528,7 +528,7 @@ TEST_CASE( "shot_features", "[gun]" "[slow]" )
 
     // Lightly armored target (armor_bullet: 5)
     // Outcomes for lightly armored enemies are very similar.
-    shoot_monster( "shotgun_s", {}, "shot_00", 18, 33, "mon_zombie_brute" );
+    shoot_monster( "shotgun_s", {}, "shot_00", 18, 20, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 12, 40, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 5, 116, "mon_zombie_brute" );
     shoot_monster( "shotgun_s", {}, "shot_00", 1, 73, "mon_zombie_brute" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Increase penalty for having less than 10 skill from 3 dispersion per skill point to 10 dispersion per skill point.
- Previously the above penalty was added to the weapon's base dispersion multiplied by (1.25 + the amount of skill you are below 5 times 0.75). Now it is (1.25 + the amount of skill you are below 5 times 2).
- So for example if a gun had 200 base dispersion and you had 2 skill, its base dispersion of 200 was multiplied by (1.25 + 3 * 0.75 ) = 3.5x = 700 and then added to 3 * 7 (721).
- Now, it  So if you had the same 200 dispersion gun and you had 2 skill, its base dispersion of 200 was multiplied by (1.25 + 3 * 2 ) = 7.25x = 1450 and then added to 10 * 7 (1520). These penalties level off fairly quickly as you approach 5 skill.
- In case of 0 skill and a 200 dispersion gun the penalty used to be 1030. Now it is 2350.
- Aiming a gun is no longer just manipulation score. It is now 60% lifting score (arms), 20% grip score (hands) and 20% manipulation (hands)
- Normally re-orienting your aim always scales your "amount of being aimed" linearly down to 0 at 180 degrees in rotation. Now, that 180 degrees is reduced by lower marksmanship skill, being divided by the amount your skill is less than 5 (so at 0 skill changing your aim radius by 30 degrees is enough that you have to completely re aim from scratch)
- Aiming speed is much more influenced by gun skill. Previously, base aim speed cap ranged linearly from 20-30 from 0-10 gun skill. Now It is a base of 5, with +4 speed per skill level up to level 5, then +1 per level as normal up to 10, giving a range of 5-30 and reaching 25 at skill 5 just like before. This means if you "cheat" your way to fast aim speeds by having a high dexterity and target acquisition tools such as a laser sight, you will still be limited somewhat by your skill. Also, total base aim speed is reduced by 60% at skill zero, as skill "double dips" to pave over many of the other bonuses to aim speed and prevent you from making use of them. This debuff lessens in potency linearly to 7.5 skill, at which point it is completely non existent.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->