### PR TITLE
add get_instability_per_category()

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3214,7 +3214,7 @@ class Character : public Creature, public visitable
         /** Returns an enumeration of visible mutations with colors */
         std::string visible_mutations( int visibility_cap ) const;
 
-        /** 
+        /**
         * generates an integer based on how many times we've gained non-negative mutations.
         * this is asked for any given tree, but counts all of our mutations in total.
         * different than mutation_category_level[] in many ways:
@@ -3223,7 +3223,7 @@ class Character : public Creature, public visitable
         * - individually counts each step of a multi level mutation (it counts Strong *and* Very Strong as their own mutations)
         * - to explain the above: your display only shows Very Strong, but you still have Strong too under the hood, it's just suppressed.
         * - mutation_category_level[] ignores Strong and counts Very Strong as slightly more than 1 mutation, but not 2 mutations.
-        * - Meanwhile this counts Very Strong as 2 mutations, since you had to mutate Strong and then mutate that into Very Strong 
+        * - Meanwhile this counts Very Strong as 2 mutations, since you had to mutate Strong and then mutate that into Very Strong
         * - this is to mimic the behavior of the old instability vitamin, which increased by 100 each time you mutated (so Very Strong was 200 instability)
         * The final result is used to calculate our current instability (likelihood of a negative mutation)
         * so each mutation we have that belongs to a different tree than the one we specified counts double.

--- a/src/character.h
+++ b/src/character.h
@@ -3214,6 +3214,24 @@ class Character : public Creature, public visitable
         /** Returns an enumeration of visible mutations with colors */
         std::string visible_mutations( int visibility_cap ) const;
 
+        /** 
+        * generates an integer based on how many times we've gained non-negative mutations.
+        * this is asked for any given tree, but counts all of our mutations in total.
+        * different than mutation_category_level[] in many ways:
+        * - Does not count negative mutations
+        * - assigns 1 point to each level of mutation in our category, and 2 for each level out of it
+        * - individually counts each step of a multi level mutation (it counts Strong *and* Very Strong as their own mutations)
+        * - to explain the above: your display only shows Very Strong, but you still have Strong too under the hood, it's just suppressed.
+        * - mutation_category_level[] ignores Strong and counts Very Strong as slightly more than 1 mutation, but not 2 mutations.
+        * - Meanwhile this counts Very Strong as 2 mutations, since you had to mutate Strong and then mutate that into Very Strong 
+        * - this is to mimic the behavior of the old instability vitamin, which increased by 100 each time you mutated (so Very Strong was 200 instability)
+        * The final result is used to calculate our current instability (likelihood of a negative mutation)
+        * so each mutation we have that belongs to a different tree than the one we specified counts double.
+        * example: you start with Trog and mutate Slimy and Light Sensitive. Within Trog you have 2 points.
+        * you then go to mutate Rat. Rat has Light Sensitive but not Slimy, so you have 1+2=3 points.
+        */
+        int get_instability_per_category( mutation_category_id &categ );
+
         player_activity get_destination_activity() const;
         void set_destination_activity( const player_activity &new_destination_activity );
         void clear_destination_activity();

--- a/src/character.h
+++ b/src/character.h
@@ -3230,7 +3230,7 @@ class Character : public Creature, public visitable
         * example: you start with Trog and mutate Slimy and Light Sensitive. Within Trog you have 2 points.
         * you then go to mutate Rat. Rat has Light Sensitive but not Slimy, so you have 1+2=3 points.
         */
-        int get_instability_per_category( mutation_category_id &categ );
+        int get_instability_per_category( mutation_category_id &categ ) const;
 
         player_activity get_destination_activity() const;
         void set_destination_activity( const player_activity &new_destination_activity );

--- a/src/character.h
+++ b/src/character.h
@@ -1026,6 +1026,24 @@ class Character : public Creature, public visitable
         steed_type get_steed_type() const;
         virtual void set_movement_mode( const move_mode_id &mode ) = 0;
 
+        /**
+        * generates an integer based on how many times we've gained non-negative mutations.
+        * this is asked for any given tree, but counts all of our mutations in total.
+        * different than mutation_category_level[] in many ways:
+        * - Does not count negative mutations
+        * - assigns 1 point to each level of mutation in our category, and 2 for each level out of it
+        * - individually counts each step of a multi level mutation (it counts Strong *and* Very Strong as their own mutations)
+        * - to explain the above: your display only shows Very Strong, but you still have Strong too under the hood, it's just suppressed.
+        * - mutation_category_level[] ignores Strong and counts Very Strong as slightly more than 1 mutation, but not 2 mutations.
+        * - Meanwhile this counts Very Strong as 2 mutations, since you had to mutate Strong and then mutate that into Very Strong
+        * - this is to mimic the behavior of the old instability vitamin, which increased by 100 each time you mutated (so Very Strong was 200 instability)
+        * The final result is used to calculate our current instability (likelihood of a negative mutation)
+        * so each mutation we have that belongs to a different tree than the one we specified counts double.
+        * example: you start with Trog and mutate Slimy and Light Sensitive. Within Trog you have 2 points.
+        * you then go to mutate Rat. Rat has Light Sensitive but not Slimy, so you have 1+2=3 points.
+        */
+        int get_instability_per_category( const mutation_category_id &categ ) const;
+
         /**Determine if character is susceptible to dis_type and if so apply the symptoms*/
         void expose_to_disease( const diseasetype_id &dis_type );
         /**
@@ -3213,24 +3231,6 @@ class Character : public Creature, public visitable
         int get_mutation_visibility_cap( const Character *observed ) const;
         /** Returns an enumeration of visible mutations with colors */
         std::string visible_mutations( int visibility_cap ) const;
-
-        /**
-        * generates an integer based on how many times we've gained non-negative mutations.
-        * this is asked for any given tree, but counts all of our mutations in total.
-        * different than mutation_category_level[] in many ways:
-        * - Does not count negative mutations
-        * - assigns 1 point to each level of mutation in our category, and 2 for each level out of it
-        * - individually counts each step of a multi level mutation (it counts Strong *and* Very Strong as their own mutations)
-        * - to explain the above: your display only shows Very Strong, but you still have Strong too under the hood, it's just suppressed.
-        * - mutation_category_level[] ignores Strong and counts Very Strong as slightly more than 1 mutation, but not 2 mutations.
-        * - Meanwhile this counts Very Strong as 2 mutations, since you had to mutate Strong and then mutate that into Very Strong
-        * - this is to mimic the behavior of the old instability vitamin, which increased by 100 each time you mutated (so Very Strong was 200 instability)
-        * The final result is used to calculate our current instability (likelihood of a negative mutation)
-        * so each mutation we have that belongs to a different tree than the one we specified counts double.
-        * example: you start with Trog and mutate Slimy and Light Sensitive. Within Trog you have 2 points.
-        * you then go to mutate Rat. Rat has Light Sensitive but not Slimy, so you have 1+2=3 points.
-        */
-        int get_instability_per_category( mutation_category_id &categ ) const;
 
         player_activity get_destination_activity() const;
         void set_destination_activity( const player_activity &new_destination_activity );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -170,6 +170,22 @@ int Character::count_trait_flag( const json_character_flag &b ) const
     return ret;
 }
 
+int Character::get_instability_per_category( const mutation_category_id &categ ) const
+{
+    int mut_count = 0;
+    for( const trait_id &mut : get_mutations() ) {
+        const mutation_branch &mdata = mut.obj();
+        if( mdata.points > -1 && !mdata.threshold ) {
+            if( mdata.category == categ ) {
+                mut_count += 1;
+            } else {
+                mut_count += 2;
+            }
+        }
+    }
+    return mut_count;
+}
+
 bool Character::has_base_trait( const trait_id &b ) const
 {
     // Look only at base traits
@@ -2465,19 +2481,4 @@ std::string Character::visible_mutations( const int visibility_cap ) const
 
         return std::string();
     } );
-}
-int Character::get_instability_per_category( const mutation_category_id &categ ) const
-{
-    int mut_count = 0;
-    for( const trait_id &mut : get_mutations() ) {
-        const mutation_branch &mdata = mut.obj();
-        if( mdata.points > -1 !mdata.flags.count( json_flag_NON_THRESH ) ) {
-            if( mdata.category == categ ) {
-                mut_count += 1;
-            } else {
-                mut_count += 2;
-            }
-        }
-    }
-    return mut_count;
 }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -2466,21 +2466,7 @@ std::string Character::visible_mutations( const int visibility_cap ) const
         return std::string();
     } );
 }
-
-// generates an integer based on how many times we've gained non-negative mutations.
-// this is asked for any given tree, but counts all of our mutations in total.
-// different than mutation_category_level[] in many ways:
-// - Does not count negative mutations
-// - assigns 1 point to each level of mutation in our category, and 2 for each level out of it
-// - individually counts each step of a multi level mutation (it counts Strong *and* Very Strong as their own mutations)
-// - to explain the above: your display only shows Very Strong, but you still have Strong too under the hood, it's just suppressed.
-// - mutation_category_level[] ignores Strong and counts Very Strong as slightly more than 1 mutation, but not 2 mutations.
-// - Meanwhile this counts Very Strong as 2 mutations, since you had to mutate Strong and then mutate that into Very Strong 
-// - this is to mimic the behavior of the old instability vitamin, which increased by 100 each time you mutated (so Very Strong was 200 instability)
-// The final result is used to calculate our current instability (likelihood of a negative mutation)
-// so each mutation we have that belongs to a different tree than the one we specified counts double.
-// example: you start with Trog and mutate Slimy and Light Sensitive. Within Trog you have 2 points.
-// you then go to mutate Rat. Rat has Light Sensitive but not Slimy, so you have 1+2=3 points. 
+ 
 int Character::get_instability_per_category( const mutation_category_id &categ ) const
 {
     int mut_count = 0;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -2466,7 +2466,6 @@ std::string Character::visible_mutations( const int visibility_cap ) const
         return std::string();
     } );
 }
- 
 int Character::get_instability_per_category( const mutation_category_id &categ ) const
 {
     int mut_count = 0;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -176,7 +176,13 @@ int Character::get_instability_per_category( const mutation_category_id &categ )
     for( const trait_id &mut : get_mutations() ) {
         const mutation_branch &mdata = mut.obj();
         if( mdata.points > -1 && !mdata.threshold ) {
-            if( mdata.category == categ ) {
+            bool in_categ = false;
+            for( const mutation_category_id &Ch_cat : mdata.allowed_category ) {
+                if( Ch_cat == categ ) {
+                    in_categ = true;
+                }
+            }
+            if( in_categ ) {
                 mut_count += 1;
             } else {
                 mut_count += 2;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Instability is a function of how many mutations you have, and does not decay unless you use purifier to reduce your total mutations. Only positive/neutral mutations are counted. If you swap mutations (such as cat ears -> dog ears) your count remains the same since you're still "1 mutation deep" on your ears)
- It is calculated on a per tree basis, with mutations you have that don't appear in that tree counting double as ones that do.
- Only counts mutations, not traits (unlike thresholding which counts traits too) so if you start the game with say 5 "cat" traits and go into Cat formally and cat has 25 total good mutations, you only had a 40% bad mut odds at the 25th mut rather than a 50% (total avg of 4 total bad muts instead of 6)
- when you mutate, you might sometimes additionally mutate a negative trait alongside your positive trait rather than your negative trait replacing the positive trait. (based on instability odds)
- the bad mutation odds >0 after 1 mutation (first is free), then scale up to 50% bad mut rate at the total number of good mutations in the tree (so alpha and chimera progress instability at different rates, but overall will end up with about 1 bad mutation for every 4 good if they get every mutation in the tree)
- counts sequential mutations individually (so strong -> very strong is a total of 1+1 points, since it took 2 total)
- robust subtracts 5 from your "mutation count" for determining instability


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make mutating respect the number of traits in the category somehow? alpha gets very few while insect and chimera get a ton...
add a function to count the number of mutations any given category has
Make roll bad mutation take category as an arg, and then make its 50% badmut odds the number of mutations in the tree * 2 (or *3 with robust genes) (or something)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
